### PR TITLE
Fix chunking edge case for small texts

### DIFF
--- a/gpt3summarizer.py
+++ b/gpt3summarizer.py
@@ -88,6 +88,9 @@ class GPT3Summarizer:
                 buffer = ""
                 token_count = 0
                 
+        if buffer:
+            chunks.append(buffer)
+            
         print(f'↪ Chunks: {len(chunks)} ({transcript.count(".")} sentences)')
         
         return chunks


### PR DESCRIPTION
When token length < 3000, process_chunks did not process the transcript text. This fixes that edge case, and also ensures that any trailing buffered text near a chunk boundary gets appended for summarization.